### PR TITLE
Add personal_sign and personal_ecRecover support

### DIFF
--- a/src/schema.json
+++ b/src/schema.json
@@ -5,6 +5,8 @@
     "net_version": [[], "S"],
     "net_peerCount": [[], "Q"],
     "net_listening": [[], "B"],
+    "personal_sign": [["D20", "D", "S"], "D", 2],
+    "personal_ecRecover": [["D", "D"], "D20", 2],
     "eth_protocolVersion": [[], "S"],
     "eth_syncing": [[], "Boolean|EthSyncing"],
     "eth_coinbase": [[], "D20"],


### PR DESCRIPTION
These methods were added to geth after [this discussion](https://github.com/ethereum/go-ethereum/pull/2940).

The methods and their types are these:

- personal_sign takes an address and an arbitrary hex message to sign, returns a variable-length signed message.
- personal_ecRecover takes the original arbitrary hex message, and the signed output of `personal_sign`, and returns the address that signed it.

Let me know if there's anything I missed.  Looks like maybe there's a build step?  I don't see a test suite here, and it's pretty declarative, so I suppose that has to rest for now.