### PR TITLE
Correct personal_sign param ordering

### DIFF
--- a/src/schema.json
+++ b/src/schema.json
@@ -5,7 +5,7 @@
     "net_version": [[], "S"],
     "net_peerCount": [[], "Q"],
     "net_listening": [[], "B"],
-    "personal_sign": [["D20", "D", "S"], "D", 2],
+    "personal_sign": [["D", "D20", "S"], "D", 2],
     "personal_ecRecover": [["D", "D"], "D20", 2],
     "eth_protocolVersion": [[], "S"],
     "eth_syncing": [[], "Boolean|EthSyncing"],


### PR DESCRIPTION
[It has been brought to my attention](https://github.com/MetaMask/metamask-plugin/issues/1557) that this (and in turn MetaMask's) personal_sign param ordering is incorrect.

How did this happen? Was it [the lack of a standard RPC test suite?](https://github.com/ethereum/EIPs/issues/217) was it just my mistake? I'll claim both.

The Wiki seems to be accurate in correcting us here, too:
https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_sign