### PR TITLE
eth_syncing Primitive boolean not compressed

### DIFF
--- a/src/schema.json
+++ b/src/schema.json
@@ -8,7 +8,7 @@
     "personal_sign": [["D20", "D", "S"], "D", 2],
     "personal_ecRecover": [["D", "D"], "D20", 2],
     "eth_protocolVersion": [[], "S"],
-    "eth_syncing": [[], "Boolean|EthSyncing"],
+    "eth_syncing": [[], "B|EthSyncing"],
     "eth_coinbase": [[], "D20"],
     "eth_mining": [[], "B"],
     "eth_hashrate": [[], "Q"],

--- a/src/schema.json
+++ b/src/schema.json
@@ -154,7 +154,7 @@
       "__required": [],
       "fromBlock": "Q|T",
       "toBlock": "Q|T",
-      "address": "Array|Data",
+      "address": "Array|DATA",
       "topics": ["D"]
     },
     "FilterChange": {


### PR DESCRIPTION
Seems to me the return values should be compressed `B`, not `Boolean` (which is an undefined object)