### PR TITLE
Corrected signTypedData schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethjs-schema",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A complete Ethereum RPC specification as a JSON object export.",
   "main": "src/schema.json",
   "files": [

--- a/src/schema.json
+++ b/src/schema.json
@@ -24,7 +24,7 @@
     "eth_getUncleCountByBlockNumber": [["Q"], "Q", 1],
     "eth_getCode": [["D20", "Q|T"], "D", 1, 2],
     "eth_sign": [["D20", "D32"], "D", 2],
-    "eth_signTypedData": ["D32", "D", 1],
+    "eth_signTypedData": [["Array|DATA", "D20"], "D", 1],
     "eth_sendTransaction": [["SendTransaction"], "D", 1],
     "eth_sendRawTransaction": [["D"], "D32", 1],
     "eth_call": [["CallTransaction", "Q|T"], "D", 1, 2],


### PR DESCRIPTION
Had mis-formatted the previous schema pretty badly. Shot in the dark. Now actually built everything up to `ethjs` to ensure it works on a branch of my [signature examples page](https://danfinlay.github.io/js-eth-personal-sign-examples/).